### PR TITLE
【ユーザー登録・ログイン】登録フォームからNameを消す

### DIFF
--- a/yeahcheese/app/Http/Controllers/Auth/RegisterController.php
+++ b/yeahcheese/app/Http/Controllers/Auth/RegisterController.php
@@ -50,7 +50,6 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ]);
@@ -65,7 +64,6 @@ class RegisterController extends Controller
     protected function create(array $data)
     {
         return User::create([
-            'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);

--- a/yeahcheese/app/User.php
+++ b/yeahcheese/app/User.php
@@ -17,7 +17,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+        'email', 'password',
     ];
 
     /**

--- a/yeahcheese/database/migrations/2020_05_13_014343_drop_column_name_column.php
+++ b/yeahcheese/database/migrations/2020_05_13_014343_drop_column_name_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropColumnNameColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('name');
+        });
+    }
+}

--- a/yeahcheese/resources/views/auth/register.blade.php
+++ b/yeahcheese/resources/views/auth/register.blade.php
@@ -12,20 +12,6 @@
                         @csrf
 
                         <div class="form-group row">
-                            <label for="name" class="col-md-4 col-form-label text-md-right">{{ __('Name') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus>
-
-                                @error('name')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
                             <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
 
                             <div class="col-md-6">


### PR DESCRIPTION
close #12 

### 目的

- Laravelの認証機能はusersテーブルにnameがあり、それをユーザー登録時に入力する仕様になっているが、今回nameは不要なので表示を消す。

### 動作確認

- ユーザー登録画面（ https://yeahcheese.localapp.jp/register ）のフォームがemailとpasswordになってること
![image](https://user-images.githubusercontent.com/54708270/81768485-1efdf380-9516-11ea-8483-66f0bea19325.png)
- 入力して登録ができること
- その内容でloginできること

### コーディング規約の確認

- 4ファイルとも確認済み