### PR TITLE
全イベントデータをイベント一覧画面に表示する

### DIFF
--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Event;
 use Illuminate\Http\Request;
 
 class EventController extends Controller
@@ -13,7 +14,8 @@ class EventController extends Controller
      */
     public function index()
     {
-        return view('events.index');
+        $events = Event::all();
+        return view('events.index', [ 'events' => $events ]);
     }
 
     /**

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use App\Event;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class EventController extends Controller
 {
@@ -14,7 +14,7 @@ class EventController extends Controller
      */
     public function index()
     {
-        $events = Event::all();
+        $events = Auth::user()->event()->get();
         return view('events.index', [ 'events' => $events ]);
     }
 

--- a/yeahcheese/resources/views/events/index.blade.php
+++ b/yeahcheese/resources/views/events/index.blade.php
@@ -7,5 +7,15 @@
     </head>
     <body>
         <h1>イベント一覧</h1>
+        @foreach ($events as $event)
+            <p>
+                {{ $event->id }},
+                {{ $event->name }},
+                {{ $event->start_at }},
+                {{ $event->end_at }},
+                {{ $event->authorization_key }},
+                {{ $event->user_id }}
+            </p>
+        @endforeach
     </body>
 </html>


### PR DESCRIPTION
close #26 

## 改修内容

登録されているイベントをとりあえずイベント一覧画面に表示できるようにした。

＊created_at, updated_atは表示するとしたら詳細画面でいいかなと思い、一覧画面には表示していない。

## 動作確認

- データベースにsqlで4レコード作成
- id:1, 5でそれぞれログインし、イベント一覧画面( https://yeahcheese.localapp.jp/events )でuser_idが一致しているイベントのみ表示されることを確認済み

<img width="836" alt="スクリーンショット 2020-05-15 15 15 26" src="https://user-images.githubusercontent.com/54708270/82017948-37f5d880-96bf-11ea-970d-19c98e71d1ae.png">

こんな感じ。

![image](https://user-images.githubusercontent.com/54708270/82018024-5956c480-96bf-11ea-8b6a-3d293f44cff8.png)
