### PR TITLE
Bootstrapを使って共通テンプレート（ヘッダー）を作る

### DIFF
--- a/yeahcheese/resources/views/events/header.blade.php
+++ b/yeahcheese/resources/views/events/header.blade.php
@@ -1,0 +1,28 @@
+<nav class='navbar navbar-expand-md navbar-dark bg-dark fixed-top'>
+    <a class="navbar-brand">yamacheese</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNavDropdown">
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link" href="{{ route('events.index') }}">イベント一覧</a>
+            </li>
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                {{ Auth::user()->email }}
+                </a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                    <a class="dropdown-item" href="{{ route('logout') }}"
+                        onclick="event.preventDefault();
+                            document.getElementById('logout-form').submit();">
+                        {{ __('Logout') }}
+                    </a>
+                    <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                        @csrf
+                    </form>
+                </div>
+            </li>
+        </ul>
+    </div>
+</nav>

--- a/yeahcheese/resources/views/events/index.blade.php
+++ b/yeahcheese/resources/views/events/index.blade.php
@@ -1,21 +1,15 @@
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset='utf-8'>
-        <title>event list</title>
-        <style>body {padding: 10px;}</style>
-    </head>
-    <body>
-        <h1>イベント一覧</h1>
-        @foreach ($events as $event)
-            <p>
-                {{ $event->id }},
-                {{ $event->name }},
-                {{ $event->start_at }},
-                {{ $event->end_at }},
-                {{ $event->authorization_key }},
-                {{ $event->user_id }}
-            </p>
-        @endforeach
-    </body>
-</html>
+@extends('events.layout')
+
+@section('content')
+    <h1>イベント一覧</h1>
+    @foreach ($events as $event)
+        <p>
+            {{ $event->id }},
+            {{ $event->name }},
+            {{ $event->start_at }},
+            {{ $event->end_at }},
+            {{ $event->authorization_key }},
+            {{ $event->user_id }}
+        </p>
+    @endforeach
+@endsection

--- a/yeahcheese/resources/views/events/layout.blade.php
+++ b/yeahcheese/resources/views/events/layout.blade.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset='utf-8'>
+        <title>layout</title>
+        <style>body {padding: 80px;}</style>
+        @include('style-sheet')
+    </head>
+    <body>
+        @include('events.header')
+        <div class='container'>
+            @yield('content')
+        </div>
+    </body>
+</html>

--- a/yeahcheese/resources/views/style-sheet.blade.php
+++ b/yeahcheese/resources/views/style-sheet.blade.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+        <!-- Bootstrap CSS -->
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    </head>
+    <body>
+
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    </body>
+</html>


### PR DESCRIPTION
close #30 

## 改修内容

イベント一覧・編集・新規作成画面の共通部分を作った。

- style-sheet.blade.php はbootstrapのドキュメントにある[スターターテンプレート](https://getbootstrap.jp/docs/4.4/getting-started/introduction/#%E3%82%B9%E3%82%BF%E3%83%BC%E3%82%BF%E3%83%BC%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88)を使用。

- header.blade.php は[Navbarのコンポーネントの例](https://getbootstrap.jp/docs/4.2/components/navbar/)を参考にした。

- ログアウトの処理は元の[ /resources/views/layouts/app.blade.php ファイル](https://github.com/sen-newface/yamacheese/blob/master/yeahcheese/resources/views/layouts/app.blade.php#L57)の処理を拝借。

- 他のページでも使えるように、index.blade.phpの一部をlayout.blade.phpに切り出した。



## 動作確認

見た目はこんな感じになっている。
今はまだイベント一覧しかないので、表示の確認はイベント一覧画面（ https://yeahcheese.localapp.jp/events ）で行う。
![image](https://user-images.githubusercontent.com/54708270/82165377-b933b200-98ef-11ea-9328-4d6c0ec5535b.png)

- 「yamacheese」はリンクなし。
- イベント一覧をクリックするとイベント一覧に遷移。
- メアドはログインしているアカウントのメアドが表示されている。
- メアド押下後「ログアウト」が出現して、クリックするとログアウトされる。（ログイン画面に遷移）


