### PR TITLE
イベント新規投稿フォームの作成

### DIFF
--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -108,10 +108,8 @@ class EventController extends Controller
     public function existAuthorizationKey($code)
     {
         $authorizationkeys = Event::all()->pluck('authorization_key');
-        foreach ($authorizationkeys as $authorizationkey) {
-            if ($code === $authorizationkey) {
-                return true;
-            }
+        if ($authorizationkeys->contains($code)) {
+            return true;
         }
         return false;
     }

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -83,4 +83,22 @@ class EventController extends Controller
     {
         //
     }
+
+    public function makeAuthorizationKey($length = 8) {
+        $max = pow(10, $length) - 1;
+        $rand = random_int(0, $max);
+        $code = sprintf('%0'. $length. 'd', $rand);
+
+        $events = Event::all()->pluck('authorization_key');
+        foreach ($events as $id => $authorizationkey) {
+            if ($code === $authorizationkey) {
+                $max = pow(10, $length) - 1;
+                $rand = random_int(0, $max);
+                $code = sprintf('%0'. $length. 'd', $rand);
+            }
+            $code = $code;
+        }
+
+        return $code;
+    }
 }

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -104,8 +104,8 @@ class EventController extends Controller
         $rand = random_int(0, $max);
         $code = sprintf('%0'. $length. 'd', $rand);
 
-        $events = Event::all()->pluck('authorization_key');
-        foreach ($events as $id => $authorizationkey) {
+        $authorizationkeys = Event::all()->pluck('authorization_key');
+        foreach ($authorizationkeys as $id => $authorizationkey) {
             if ($code === $authorizationkey) {
                 $max = pow(10, $length) - 1;
                 $rand = random_int(0, $max);

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -45,7 +45,9 @@ class EventController extends Controller
 
         $event = new Event();
 
-        $event->fill($request->all());
+        $event->name = $request->name;
+        $event->start_at = $request->start_at;
+        $event->end_at = $request->end_at;
         $event->authorization_key = EventController::makeAuthorizationKey();
         $event->user_id = Auth::user()->id;
         $event->save();
@@ -97,32 +99,22 @@ class EventController extends Controller
         //
     }
 
-    public function makeAuthorizationKey()
+    public function makeAuthorizationKey($length = 8)
     {
-        // 8桁の数字を作る
-        $length = 8;
         $max = pow(10, $length) - 1;
         $rand = random_int(0, $max);
-        return sprintf('%0'. $length. 'd', $rand);
-    }
+        $code = sprintf('%0'. $length. 'd', $rand);
 
-    public function existAuthorizationKey($code)
-    {
-        $events = Event::all()->pluck('authorization_key');  // 今あるkeyを全部とってくる
-        foreach ($events as $authorizationkey) {  // 今あるkeyを1つ1つ取り出す
-            if ($code === $authorizationkey) {  // 比較して、同じkeyがあったら、8桁の数字を作り直す
-                return true;
+        $events = Event::all()->pluck('authorization_key');
+        foreach ($events as $id => $authorizationkey) {
+            if ($code === $authorizationkey) {
+                $max = pow(10, $length) - 1;
+                $rand = random_int(0, $max);
+                $code = sprintf('%0'. $length. 'd', $rand);
             }
+            $code = $code;
         }
-        return false;
-    }
 
-    public function remakeAuthorizationKey()
-    {
-        $a = $this->makeAuthorizationKey();
-        if ($this->existAuthorizationKey($a)) {
-            $this->remakeAuthorizationKey();
-        }
-        return $a;
+        return $code;
     }
 }

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -97,23 +97,31 @@ class EventController extends Controller
         //
     }
 
-    public function makeAuthorizationKey()
+    public function eightDigitNumber()
     {
         $length = 8;
         $max = pow(10, $length) - 1;
         $rand = random_int(0, $max);
-        $code = sprintf('%0'. $length. 'd', $rand);
+        return sprintf('%0'. $length. 'd', $rand);
+    }
 
+    public function existAuthorizationKey($code)
+    {
         $authorizationkeys = Event::all()->pluck('authorization_key');
         foreach ($authorizationkeys as $authorizationkey) {
             if ($code === $authorizationkey) {
-                $max = pow(10, $length) - 1;
-                $rand = random_int(0, $max);
-                $code = sprintf('%0'. $length. 'd', $rand);
+                return true;
             }
-            $code = $code;
         }
+        return false;
+    }
 
+    public function makeAuthorizationKey()
+    {
+        $code = $this->eightDigitNumber();
+        if ($this->existAuthorizationKey($code)) {
+            $this->makeAuthorizationKey();
+        }
         return $code;
     }
 }

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -36,7 +36,16 @@ class EventController extends Controller
      */
     public function store(Request $request)
     {
-        //
+
+        $event = new Event();
+
+        $event->name = $request->name;
+        $event->start_at = $request->start_at;
+        $event->end_at = $request->end_at;
+        $event->authorization_key = EventController::makeAuthorizationKey();
+        $event->user_id = Auth::user()->id;
+        $event->save();
+        return redirect('/events');
     }
 
     /**

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -23,9 +23,9 @@ class EventController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function create()
+    public function create(Request $request)
     {
-        //
+        return view('events.create');
     }
 
     /**

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -99,7 +99,8 @@ class EventController extends Controller
         //
     }
 
-    public function makeAuthorizationKey($length = 8) {
+    public function makeAuthorizationKey($length = 8)
+    {
         $max = pow(10, $length) - 1;
         $rand = random_int(0, $max);
         $code = sprintf('%0'. $length. 'd', $rand);

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -45,9 +45,7 @@ class EventController extends Controller
 
         $event = new Event();
 
-        $event->name = $request->name;
-        $event->start_at = $request->start_at;
-        $event->end_at = $request->end_at;
+        $event->fill($request->all());
         $event->authorization_key = EventController::makeAuthorizationKey();
         $event->user_id = Auth::user()->id;
         $event->save();

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -37,6 +37,10 @@ class EventController extends Controller
      */
     public function store(Request $request)
     {
+        $request->validate([
+            'start_at' => 'nullable|required_with:end_at|date_format:Y-m-d',
+            'end_at' => 'nullable|required_with:start_at|after_or_equal:start_at|date_format:Y-m-d',
+        ]);
 
         $event = new Event();
 

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -105,7 +105,7 @@ class EventController extends Controller
         $code = sprintf('%0'. $length. 'd', $rand);
 
         $authorizationkeys = Event::all()->pluck('authorization_key');
-        foreach ($authorizationkeys as $id => $authorizationkey) {
+        foreach ($authorizationkeys as $authorizationkey) {
             if ($code === $authorizationkey) {
                 $max = pow(10, $length) - 1;
                 $rand = random_int(0, $max);

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Event;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -97,8 +97,9 @@ class EventController extends Controller
         //
     }
 
-    public function makeAuthorizationKey($length = 8)
+    public function makeAuthorizationKey()
     {
+        $length = 8;
         $max = pow(10, $length) - 1;
         $rand = random_int(0, $max);
         $code = sprintf('%0'. $length. 'd', $rand);

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -38,8 +38,9 @@ class EventController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'start_at' => 'nullable|required_with:end_at|date_format:Y-m-d',
-            'end_at' => 'nullable|required_with:start_at|after_or_equal:start_at|date_format:Y-m-d',
+            'name' => 'filled',
+            'start_at' => 'filled|required_with:end_at|date_format:Y-m-d',
+            'end_at' => 'filled|required_with:start_at|after_or_equal:start_at|date_format:Y-m-d',
         ]);
 
         $event = new Event();

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -24,7 +24,7 @@ class EventController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function create(Request $request)
+    public function create()
     {
         return view('events.create');
     }

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -46,7 +46,7 @@ class EventController extends Controller
         $event = new Event();
 
         $event->fill($request->all());
-        $event->authorization_key = EventController::makeAuthorizationKey();
+        $event->authorization_key = $this->makeAuthorizationKey();
         $event->user_id = Auth::user()->id;
         $event->save();
         return redirect('/events');

--- a/yeahcheese/database/migrations/2020_05_19_102837_add_unique_to_authorization_key_column.php
+++ b/yeahcheese/database/migrations/2020_05_19_102837_add_unique_to_authorization_key_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUniqueToAuthorizationKeyColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->unique('authorization_key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropUnique('events_authorization_key_unique');
+        });
+    }
+}

--- a/yeahcheese/resources/lang/ja/validation.php
+++ b/yeahcheese/resources/lang/ja/validation.php
@@ -148,5 +148,8 @@ return [
     'attributes' => [
         'email'=>'メールアドレス',
         'password'=>'パスワード',
+        'name'=>'イベント名',
+        'start_at'=>'公開開始日',
+        'end_at'=>'公開終了日',
     ],
 ];

--- a/yeahcheese/resources/views/events/create.blade.php
+++ b/yeahcheese/resources/views/events/create.blade.php
@@ -2,6 +2,15 @@
 
 @section('content')
     <h1>イベント新規作成</h1>
+    @if ($errors->any())
+        <div class="alert alert-danger">
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
     <form action="/events" method="POST">
         {{ csrf_field() }}
         <div>

--- a/yeahcheese/resources/views/events/create.blade.php
+++ b/yeahcheese/resources/views/events/create.blade.php
@@ -1,0 +1,23 @@
+@extends('events.layout')
+
+@section('content')
+    <h1>イベント新規作成</h1>
+    <form action="/events" method="POST">
+        {{ csrf_field() }}
+        <div>
+            <label>イベント名</label><br>
+            <input type="text" name="name" />
+        </div>
+        <div>
+            <label>公開開始日</label><br>
+            <input type="date" name="start_at" />
+        </div>
+        <div>
+            <label>公開終了日</label><br>
+            <input type="date" name="end_at" />
+        </div>
+        <div>
+            <input type="submit" value="作成する" />
+        </div>
+    </form>
+@endsection

--- a/yeahcheese/resources/views/events/create.blade.php
+++ b/yeahcheese/resources/views/events/create.blade.php
@@ -6,15 +6,15 @@
         {{ csrf_field() }}
         <div>
             <label>イベント名</label><br>
-            <input type="text" name="name" />
+            <input type="text" name="name" value="{{old('name')}}" />
         </div>
         <div>
             <label>公開開始日</label><br>
-            <input type="date" name="start_at" />
+            <input type="date" name="start_at" value="{{old('start_at')}}" />
         </div>
         <div>
             <label>公開終了日</label><br>
-            <input type="date" name="end_at" />
+            <input type="date" name="end_at" value="{{old('end_at')}}" />
         </div>
         <div>
             <input type="submit" value="作成する" />

--- a/yeahcheese/resources/views/events/index.blade.php
+++ b/yeahcheese/resources/views/events/index.blade.php
@@ -12,4 +12,7 @@
             {{ $event->user_id }}
         </p>
     @endforeach
+    <div>
+        <a href="{{ route('events.create') }}" class='btn btn-outline-primary'>イベント新規作成</a>
+    </div>
 @endsection

--- a/yeahcheese/routes/web.php
+++ b/yeahcheese/routes/web.php
@@ -23,4 +23,6 @@ Route::get('/home', 'HomeController@index')->name('home');
 
 Route::middleware('auth')->group(function () {
     Route::get('/events', 'EventController@index')->name('events.index');
+    Route::get('/events/create', 'EventController@create')->name('events.create');
+    Route::post('/events', 'EventController@store')->name('events.store');
 });


### PR DESCRIPTION
close #29 

## 改修内容

create, storeメソッドを追加し、イベント新規投稿フォームを作成した。
<img width="574" alt="スクリーンショット 2020-05-19 10 39 29" src="https://user-images.githubusercontent.com/54708270/82275218-1fd2d180-99bd-11ea-99ce-c241b5a77271.png">

### 投稿フォーム( https://yeahcheese.localapp.jp/events/create )

- 入力するのは３項目
  - イベント名（必須）
  - 公開開始日（必須）
  - 公開終了日（必須）（公開開始日と同じもしくはそれ以降でないといけない）
- eventsテーブルはこの他にauthorization_keyとuser_idを登録する必要があるので、storeメソッドでそれらを用意

### イベント一覧( https://yeahcheese.localapp.jp/events )

- イベント新規作成ボタンを設置


## 動作確認

- ログインしていない状態で https://yeahcheese.localapp.jp/events/create にアクセスするとlogin画面にリダイレクト
- ログインし、イベント一覧から「イベント新規作成」ボタンを押下し、https://yeahcheese.localapp.jp/events/create に遷移することを確認
- 何も入力しないで「作成するボタン」を押すとバリデーションエラーが表示される
- それぞれ入力して「作成するぼたん」を押すと、イベント一覧に遷移し、今登録したイベントの情報が表示されている


![image](https://user-images.githubusercontent.com/54708270/82275658-447b7900-99be-11ea-9a65-3f9e98d85632.png)

同一キーが登録できないことの確認は
- migrateを実行
- EventControllerのstoreメソッド内のキー指定部分を、既にあるキーに直接書き換えてイベントを作成する
<img width="841" alt="スクリーンショット 2020-05-20 11 30 00" src="https://user-images.githubusercontent.com/54708270/82398422-c2f31c00-9a8d-11ea-83d2-16025ee0ea22.png">

- するとこんなエラーが表示される
<img width="1247" alt="スクリーンショット 2020-05-19 20 01 28" src="https://user-images.githubusercontent.com/54708270/82398458-d8684600-9a8d-11ea-9bee-0ff586a3f692.png">

