### PR TITLE
イベント編集画面の作成/

### DIFF
--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -69,9 +69,9 @@ class EventController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function edit($id)
+    public function edit(Event $event)
     {
-        //
+        return view('events.edit', ['event' => $event]);
     }
 
     /**

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -78,12 +78,19 @@ class EventController extends Controller
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(Request $request)
     {
-        //
+        $request->validate([
+            'name' => 'filled',
+            'start_at' => 'filled|required_with:end_at|date_format:Y-m-d',
+            'end_at' => 'filled|required_with:start_at|after_or_equal:start_at|date_format:Y-m-d',
+        ]);
+
+        $event = Event::find($request->id);
+        $event->fill($request->all())->save();
+        return redirect()->route('events.edit', $event);
     }
 
     /**

--- a/yeahcheese/resources/views/events/edit.blade.php
+++ b/yeahcheese/resources/views/events/edit.blade.php
@@ -19,15 +19,15 @@
         <input type='hidden' name='user_id' value='{{ $event->user_id }}' />
         <div>
             <label>イベント名</label><br>
-            <input type="text" name="name" value="{{old('name')}}" />
+            <input type="text" name="name" value="{{old('name', $event->name)}}" />
         </div>
         <div>
             <label>公開開始日</label><br>
-            <input type="date" name="start_at" value="{{old('start_at')}}" />
+            <input type="date" name="start_at" value="{{old('start_at', $event->start_at)}}" />
         </div>
         <div>
             <label>公開終了日</label><br>
-            <input type="date" name="end_at" value="{{old('end_at')}}" />
+            <input type="date" name="end_at" value="{{old('end_at', $event->end_at)}}" />
         </div>
         <div>
             <input type="submit" value="作成する" />

--- a/yeahcheese/resources/views/events/edit.blade.php
+++ b/yeahcheese/resources/views/events/edit.blade.php
@@ -14,6 +14,9 @@
     <form action="{{ route('events.update', $event) }}" method="POST">
         {{ method_field('PUT') }}
         {{ csrf_field() }}
+        <input type='hidden' name='id' value='{{ $event->id }}' />
+        <input type='hidden' name='authorization_key' value='{{ $event->authorization_key }}' />
+        <input type='hidden' name='user_id' value='{{ $event->user_id }}' />
         <div>
             <label>イベント名</label><br>
             <input type="text" name="name" value="{{old('name')}}" />

--- a/yeahcheese/resources/views/events/edit.blade.php
+++ b/yeahcheese/resources/views/events/edit.blade.php
@@ -30,7 +30,7 @@
             <input type="date" name="end_at" value="{{old('end_at', $event->end_at)}}" />
         </div>
         <div>
-            <input type="submit" value="作成する" />
+            <input type="submit" value="更新する" />
         </div>
     </form>
 @endsection

--- a/yeahcheese/resources/views/events/edit.blade.php
+++ b/yeahcheese/resources/views/events/edit.blade.php
@@ -1,0 +1,32 @@
+@extends('events.layout')
+
+@section('content')
+    <h1>イベント編集</h1>
+    @if ($errors->any())
+        <div class="alert alert-danger">
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+    <form action="/events" method="POST">
+        {{ csrf_field() }}
+        <div>
+            <label>イベント名</label><br>
+            <input type="text" name="name" value="{{old('name')}}" />
+        </div>
+        <div>
+            <label>公開開始日</label><br>
+            <input type="date" name="start_at" value="{{old('start_at')}}" />
+        </div>
+        <div>
+            <label>公開終了日</label><br>
+            <input type="date" name="end_at" value="{{old('end_at')}}" />
+        </div>
+        <div>
+            <input type="submit" value="作成する" />
+        </div>
+    </form>
+@endsection

--- a/yeahcheese/resources/views/events/edit.blade.php
+++ b/yeahcheese/resources/views/events/edit.blade.php
@@ -11,7 +11,8 @@
             </ul>
         </div>
     @endif
-    <form action="/events" method="POST">
+    <form action="{{ route('events.update', $event) }}" method="POST">
+        {{ method_field('PUT') }}
         {{ csrf_field() }}
         <div>
             <label>イベント名</label><br>

--- a/yeahcheese/resources/views/events/index.blade.php
+++ b/yeahcheese/resources/views/events/index.blade.php
@@ -10,6 +10,9 @@
             {{ $event->end_at }},
             {{ $event->authorization_key }},
             {{ $event->user_id }}
+            <div>
+                <a href="{{ route('events.edit', $event) }}" class='btn btn-outline-primary'>編集する</a>
+            </div>
         </p>
     @endforeach
     <div>

--- a/yeahcheese/routes/web.php
+++ b/yeahcheese/routes/web.php
@@ -25,4 +25,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/events', 'EventController@index')->name('events.index');
     Route::get('/events/create', 'EventController@create')->name('events.create');
     Route::post('/events', 'EventController@store')->name('events.store');
+
+    Route::get('/events/{event}/edit', 'EventController@edit')->name('events.edit');
+    Route::put('/events/{event}/edit', 'EventController@update')->name('events.update');
 });


### PR DESCRIPTION
close #33 

イベント編集画面を新しく作る。

<img width="574" alt="スクリーンショット 2020-05-21 14 18 32" src="https://user-images.githubusercontent.com/54708270/82526111-13da4180-9b6e-11ea-8800-623884a994be.png">


## 改修内容

- イベント一覧に、各イベントの編集ページへのリンク（ボタン）を設置。
- イベント編集画面で下記3つを編集、更新することができる。
  - イベント名
  - 公開開始日
  - 公開終了日
- 「更新する」ボタンを押したあとの遷移は編集画面。

＊一見更新されていることが分からないので、いずれスナックバーをつけるとか、変更前後の値を表示するようにするとかしたいが現状未対応。

＊まだ写真のアップロードはできない。

## 動作確認

- イベント一覧から、いずれかの「編集する」ボタンをクリックする
（この時、変更前の値を覚えておく）
- 選択したイベントIDの編集画面に遷移したか確認する
（ https://yeahcheese.localapp.jp/events/{id}/edit ）
- バリデーションの確認をする
- 更新できる内容で「更新する」ボタンをクリックするとそのままeditのページにリダイレクト
- イベント一覧に行き、更新したイベントの内容が合っているか確認
（認証キーは変わっていない）