### PR TITLE
【編集画面】API\PhotoControllerを作成(index, store)

### DIFF
--- a/yeahcheese/app/Http/Controllers/Api/PhotoController.php
+++ b/yeahcheese/app/Http/Controllers/Api/PhotoController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class PhotoController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/yeahcheese/app/Http/Controllers/Api/PhotoController.php
+++ b/yeahcheese/app/Http/Controllers/Api/PhotoController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Photo;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class PhotoController extends Controller
 {
@@ -25,9 +26,23 @@ class PhotoController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(Request $request, $id)
     {
-        //
+        
+        $this->validate($request, [
+            'file' => 'required|image'
+        ], [
+            'file.required' => '画像が選択されていません',
+            'file.image' => '画像ファイルではありません',
+        ]);
+
+        if ($request->file) {
+            $photo = new Photo();
+            $photo->path = Storage::putFile('public', $request->file);  // 画像を保存
+            $photo->event_id = $id;
+            $photo->save();  // DBに追加
+            return ['success' => '登録しました!'];
+        }
     }
 
     /**

--- a/yeahcheese/app/Http/Controllers/Api/PhotoController.php
+++ b/yeahcheese/app/Http/Controllers/Api/PhotoController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Photo;
 use Illuminate\Http\Request;
 
 class PhotoController extends Controller
@@ -12,9 +13,10 @@ class PhotoController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index($id)
     {
-        //
+        $photos = Photo::where('event_id', $id)->get();
+        return $photos;
     }
 
     /**

--- a/yeahcheese/app/Photo.php
+++ b/yeahcheese/app/Photo.php
@@ -7,6 +7,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Photo extends Model
 {
+    protected $fillable = [
+        'path',
+    ];
+
     /**
      * この写真が掲載されているイベントを取得
      *

--- a/yeahcheese/routes/api.php
+++ b/yeahcheese/routes/api.php
@@ -19,5 +19,4 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 });
 
 Route::get('/events/{id}/edit', 'Api\PhotoController@index');
-Route::post('/events/{id/edit', 'Api\PhotoController@store');
-Route::delete('/events/{id}/edit', 'Api\PhotoController@destroy');
+Route::post('/events/{id}/edit', 'Api\PhotoController@store');

--- a/yeahcheese/routes/api.php
+++ b/yeahcheese/routes/api.php
@@ -18,8 +18,6 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::middleware('auth')->group(function () {
-    Route::group(['middleware' => ['api']], function () {
-        Route::apiResource('events', 'Api\PhotoController');
-    });
-});
+Route::get('/events/{id}/edit', 'Api\PhotoController@index');
+Route::post('/events/{id/edit', 'Api\PhotoController@store');
+Route::delete('/events/{id}/edit', 'Api\PhotoController@destroy');

--- a/yeahcheese/routes/api.php
+++ b/yeahcheese/routes/api.php
@@ -17,3 +17,9 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::middleware('auth')->group(function () {
+    Route::group(['middleware' => ['api']], function () {
+        Route::apiResource('events', 'Api\PhotoController');
+    });
+});


### PR DESCRIPTION
close #43

イベント編集画面で写真をアップロード、取得、削除できるようにするのでその準備としてAPI\PhotoControllerを作成する。

時間の都合上、一旦index, storeメソッドのみで、destroyは別で対応。

### index

- アクセスしているイベントの写真のみを取得する。
（すなわち、 https://yeahcheese.localapp.jp/events/12/edit にアクセスしている時は、event_idが12の写真のみを取得する。）

### store

- 保存する時にevent_idカラムに、アクセスしているイベントのidを入れる。
- 保存先は yeahcheese/storage/app/public 
