### PR TITLE
【イベント一覧】イベント表示の見た目を整える

### DIFF
--- a/yeahcheese/resources/views/events/index.blade.php
+++ b/yeahcheese/resources/views/events/index.blade.php
@@ -2,18 +2,31 @@
 
 @section('content')
     <h1>イベント一覧</h1>
-    @foreach ($events as $event)
-        <p>
-            {{ $event->id }},
-            {{ $event->name }},
-            {{ $event->start_at }},
-            {{ $event->end_at }},
-            {{ $event->authorization_key }}
-            <div>
-                <a href="{{ route('events.edit', $event) }}" class='btn btn-outline-primary'>編集する</a>
-            </div>
-        </p>
-    @endforeach
+    <table class='table table-striped table-hover'>
+        @foreach ($events as $event)
+            <tr>
+                <td>
+                    {{ $event->id }}
+                </td>
+                <td>
+                    {{ $event->name }}
+                </td>
+                <td>
+                    {{ $event->start_at }}
+                </td>
+                <td>
+                    {{ $event->end_at }}
+                </td>
+                <td>
+                    {{ $event->authorization_key }}
+                </td>
+                <td>
+                    <div>
+                        <a href="{{ route('events.edit', $event) }}" class='btn btn-outline-primary'>編集する</a>
+                    </div>
+                </td>
+            </tr>
+        @endforeach
     <div>
         <a href="{{ route('events.create') }}" class='btn btn-outline-primary'>イベント新規作成</a>
     </div>

--- a/yeahcheese/resources/views/events/index.blade.php
+++ b/yeahcheese/resources/views/events/index.blade.php
@@ -3,6 +3,9 @@
 @section('content')
     <h1>イベント一覧</h1>
     <table class='table table-striped table-hover'>
+        <tr>
+            <th>イベントID</th><th>イベント名</th><th>公開開始日</th><th>公開終了日</th><th>認証キー</th><th></th>
+        </tr>
         @foreach ($events as $event)
             <tr>
                 <td>

--- a/yeahcheese/resources/views/events/index.blade.php
+++ b/yeahcheese/resources/views/events/index.blade.php
@@ -8,8 +8,7 @@
             {{ $event->name }},
             {{ $event->start_at }},
             {{ $event->end_at }},
-            {{ $event->authorization_key }},
-            {{ $event->user_id }}
+            {{ $event->authorization_key }}
             <div>
                 <a href="{{ route('events.edit', $event) }}" class='btn btn-outline-primary'>編集する</a>
             </div>


### PR DESCRIPTION
close #38 

イベント一覧画面の見た目がひどいので、テーブルタグを使用して整える。

## 改修内容

見た目調整と合わせて下記2点を対応。

- ユーザーIDの表示は不要なので削除
- カラム名を追加

![image](https://user-images.githubusercontent.com/54708270/82819726-d530e800-9edb-11ea-94e7-a74395efa32c.png)
