### PR TITLE
【編集画面】イベント更新のAPI化

### DIFF
--- a/yeahcheese/app/Http/Controllers/Api/EventController.php
+++ b/yeahcheese/app/Http/Controllers/Api/EventController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
+use App\Event;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
@@ -46,9 +47,17 @@ class EventController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(Request $request)
     {
-        //
+        $request->validate([
+            'name' => 'filled',
+            'start_at' => 'filled|required_with:end_at|date_format:Y-m-d',
+            'end_at' => 'filled|required_with:start_at|after_or_equal:start_at|date_format:Y-m-d',
+        ]);
+
+        $event = Event::find($request->id);
+        $event->fill($request->all())->save();
+        return $event;
     }
 
     /**

--- a/yeahcheese/app/Http/Controllers/Api/EventController.php
+++ b/yeahcheese/app/Http/Controllers/Api/EventController.php
@@ -35,9 +35,9 @@ class EventController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(Event $event)
     {
-        //
+        return $event;
     }
 
     /**

--- a/yeahcheese/app/Http/Controllers/Api/EventController.php
+++ b/yeahcheese/app/Http/Controllers/Api/EventController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class EventController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/yeahcheese/app/Http/Controllers/Api/EventController.php
+++ b/yeahcheese/app/Http/Controllers/Api/EventController.php
@@ -47,7 +47,7 @@ class EventController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request)
+    public function update(Request $request, Event $event)
     {
         $request->validate([
             'name' => 'filled',
@@ -55,7 +55,6 @@ class EventController extends Controller
             'end_at' => 'filled|required_with:start_at|after_or_equal:start_at|date_format:Y-m-d',
         ]);
 
-        $event = Event::find($request->id);
         $event->fill($request->all())->save();
         return $event;
     }

--- a/yeahcheese/app/Http/Controllers/EventController.php
+++ b/yeahcheese/app/Http/Controllers/EventController.php
@@ -82,15 +82,7 @@ class EventController extends Controller
      */
     public function update(Request $request)
     {
-        $request->validate([
-            'name' => 'filled',
-            'start_at' => 'filled|required_with:end_at|date_format:Y-m-d',
-            'end_at' => 'filled|required_with:start_at|after_or_equal:start_at|date_format:Y-m-d',
-        ]);
-
-        $event = Event::find($request->id);
-        $event->fill($request->all())->save();
-        return redirect()->route('events.edit', $event);
+        //
     }
 
     /**

--- a/yeahcheese/resources/js/app.js
+++ b/yeahcheese/resources/js/app.js
@@ -19,6 +19,7 @@ window.Vue = require('vue');
 // const files = require.context('./', true, /\.vue$/i)
 // files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key).default))
 
+Vue.component('eventedit-component', require('./components/EventEditComponent.vue').default);
 Vue.component('example-component', require('./components/ExampleComponent.vue').default);
 
 /**

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -1,0 +1,31 @@
+<template>
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div>
+                    <label>イベント名</label><br>
+                    <input type="text" name="name" />
+                </div>
+                <div>
+                    <label>公開開始日</label><br>
+                    <input type="date" name="start_at"  />
+                </div>
+                <div>
+                    <label>公開終了日</label><br>
+                    <input type="date" name="end_at"  />
+                </div>
+                <div>
+                    <input type="submit" value="更新する" />
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+    export default {
+        mounted() {
+            console.log('Component mounted.')
+        }
+    }
+</script>

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -15,7 +15,7 @@
                     <input type="date" name="end_at" :value="end_at"/>
                 </div>
                 <div>
-                    <input type="submit" value="更新する" />
+                    <button @click="updateEvent">更新する</button>
                 </div>
             </div>
         </div>
@@ -39,6 +39,29 @@
             end_at: {
                 type: String,
                 required: true
+            },
+            id: {
+                type: String
+            }
+        },
+        methods: {
+            updateEvent() {
+                let data = new FormData();
+                data.append("name", this.name);
+                data.append("start_at", this.start_at);
+                data.append("end_at", this.end_at);
+                data.append("id", this.id);
+    
+                axios
+                    .put("/api/events/"+this.id, data)
+                    .then(response => {
+                        this.name = "";
+                        this.start_at = "";
+                        this.end_at = "";
+                    })
+                    .catch(err => {
+                        this.message = err.response.data.errors;
+                    });
             }
         }
     }

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -4,15 +4,15 @@
             <div class="col-md-8">
                 <div>
                     <label>イベント名</label><br>
-                    <input type="text" name="name" />
+                    <input type="text" name="name" :value="name"/>
                 </div>
                 <div>
                     <label>公開開始日</label><br>
-                    <input type="date" name="start_at"  />
+                    <input type="date" name="start_at" :value="start_at"/>
                 </div>
                 <div>
                     <label>公開終了日</label><br>
-                    <input type="date" name="end_at"  />
+                    <input type="date" name="end_at" :value="end_at"/>
                 </div>
                 <div>
                     <input type="submit" value="更新する" />
@@ -26,6 +26,20 @@
     export default {
         mounted() {
             console.log('Component mounted.')
+        },
+        props: {
+            name: {
+                type: String,
+                required: true
+            },
+            start_at: {
+                type: String,
+                required: true
+            },
+            end_at: {
+                type: String,
+                required: true
+            }
         }
     }
 </script>

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -14,6 +14,7 @@
                     <label>公開終了日</label><br>
                     <input type="date" name="end_at" v-model="end_at"/>
                 </div>
+                <p>{{ message }}</p>
                 <div>
                     <button @click="updateEvent">更新する</button>
                 </div>

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -4,15 +4,15 @@
             <div class="col-md-8">
                 <div>
                     <label>イベント名</label><br>
-                    <input type="text" name="name" :value="name"/>
+                    <input type="text" name="name" v-model="name"/>
                 </div>
                 <div>
                     <label>公開開始日</label><br>
-                    <input type="date" name="start_at" :value="start_at"/>
+                    <input type="date" name="start_at" v-model="start_at"/>
                 </div>
                 <div>
                     <label>公開終了日</label><br>
-                    <input type="date" name="end_at" :value="end_at"/>
+                    <input type="date" name="end_at" v-model="end_at"/>
                 </div>
                 <div>
                     <button @click="updateEvent">更新する</button>
@@ -28,36 +28,38 @@
             console.log('Component mounted.')
         },
         props: {
-            name: {
-                type: String,
+            event: {
+                type: Object,
                 required: true
-            },
-            start_at: {
-                type: String,
-                required: true
-            },
-            end_at: {
-                type: String,
-                required: true
-            },
-            id: {
-                type: String
             }
         },
+        data() {
+            return {
+                id: 0,
+                name: '',
+                start_at: '',
+                end_at: '',
+                message: ''
+            };
+        },
+        mounted() {
+            this.id = this.event.id;
+            this.name = this.event.name;
+            this.start_at = this.event.start_at;
+            this.end_at = this.event.end_at
+        },
         methods: {
-            updateEvent() {
-                let data = new FormData();
-                data.append("name", this.name);
-                data.append("start_at", this.start_at);
-                data.append("end_at", this.end_at);
-                data.append("id", this.id);
-    
+            updateEvent() {    
                 axios
-                    .put("/api/events/"+this.id, data)
+                    .put("/api/events/"+this.id, {
+                        name: this.name,
+                        start_at: this.start_at,
+                        end_at: this.end_at
+                    })
                     .then(response => {
-                        this.name = "";
-                        this.start_at = "";
-                        this.end_at = "";
+                        this.name = this.name;
+                        this.start_at = this.start_at;
+                        this.end_at = this.end_at;
                     })
                     .catch(err => {
                         this.message = err.response.data.errors;

--- a/yeahcheese/resources/views/events/edit.blade.php
+++ b/yeahcheese/resources/views/events/edit.blade.php
@@ -8,6 +8,7 @@
                     name="{{$event->name}}"
                     start_at="{{$event->start_at}}"
                     end_at="{{$event->end_at}}"
+                    id="{{$event->id}}"
                 ></eventedit-component>
             </div>
             <script src="{{ mix('js/app.js') }}"></script>

--- a/yeahcheese/resources/views/events/edit.blade.php
+++ b/yeahcheese/resources/views/events/edit.blade.php
@@ -4,7 +4,11 @@
     <h1>イベント編集</h1>
         <body>        
             <div id="app">
-                <eventedit-component></eventedit-component>
+                <eventedit-component
+                    name="{{$event->name}}"
+                    start_at="{{$event->start_at}}"
+                    end_at="{{$event->end_at}}"
+                ></eventedit-component>
             </div>
             <script src="{{ mix('js/app.js') }}"></script>
         </body>

--- a/yeahcheese/resources/views/events/edit.blade.php
+++ b/yeahcheese/resources/views/events/edit.blade.php
@@ -5,10 +5,7 @@
         <body>        
             <div id="app">
                 <eventedit-component
-                    name="{{$event->name}}"
-                    start_at="{{$event->start_at}}"
-                    end_at="{{$event->end_at}}"
-                    id="{{$event->id}}"
+                    :event="{{json_encode($event)}}"
                 ></eventedit-component>
             </div>
             <script src="{{ mix('js/app.js') }}"></script>

--- a/yeahcheese/resources/views/events/edit.blade.php
+++ b/yeahcheese/resources/views/events/edit.blade.php
@@ -2,35 +2,10 @@
 
 @section('content')
     <h1>イベント編集</h1>
-    @if ($errors->any())
-        <div class="alert alert-danger">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
-    <form action="{{ route('events.update', $event) }}" method="POST">
-        {{ method_field('PUT') }}
-        {{ csrf_field() }}
-        <input type='hidden' name='id' value='{{ $event->id }}' />
-        <input type='hidden' name='authorization_key' value='{{ $event->authorization_key }}' />
-        <input type='hidden' name='user_id' value='{{ $event->user_id }}' />
-        <div>
-            <label>イベント名</label><br>
-            <input type="text" name="name" value="{{old('name', $event->name)}}" />
-        </div>
-        <div>
-            <label>公開開始日</label><br>
-            <input type="date" name="start_at" value="{{old('start_at', $event->start_at)}}" />
-        </div>
-        <div>
-            <label>公開終了日</label><br>
-            <input type="date" name="end_at" value="{{old('end_at', $event->end_at)}}" />
-        </div>
-        <div>
-            <input type="submit" value="更新する" />
-        </div>
-    </form>
+        <body>        
+            <div id="app">
+                <eventedit-component></eventedit-component>
+            </div>
+            <script src="{{ mix('js/app.js') }}"></script>
+        </body>
 @endsection

--- a/yeahcheese/routes/api.php
+++ b/yeahcheese/routes/api.php
@@ -21,3 +21,4 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::get('/events/{id}/edit', 'Api\PhotoController@index');
 Route::post('/events/{id}/edit', 'Api\PhotoController@store');
 Route::put('/events/{id}/edit', 'Api\EventController@update');
+Route::get('/events/{event}', 'Api\EventController@show');

--- a/yeahcheese/routes/api.php
+++ b/yeahcheese/routes/api.php
@@ -20,5 +20,5 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 Route::get('/events/{id}/edit', 'Api\PhotoController@index');
 Route::post('/events/{id}/edit', 'Api\PhotoController@store');
-Route::put('/events/{id}/edit', 'Api\EventController@update');
+Route::put('/events/{event}', 'Api\EventController@update');
 Route::get('/events/{event}', 'Api\EventController@show');

--- a/yeahcheese/routes/api.php
+++ b/yeahcheese/routes/api.php
@@ -20,3 +20,4 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 Route::get('/events/{id}/edit', 'Api\PhotoController@index');
 Route::post('/events/{id}/edit', 'Api\PhotoController@store');
+Route::put('/events/{id}/edit', 'Api\EventController@update');


### PR DESCRIPTION
close #44 

## 目的

イベント編集画面は画面遷移なしで更新できるようにする。

## 改修内容

- EventControllerのupdateをAPI側のControllerに移植＆ルーティングも設定
（Showはついでに追加。今のところ使っていない。）

- 編集画面（edit.blade.php）をvueを使って表示する為にcomponentとvueファイル追加

- バリデーションエラーは表示はされているが、jsonそのままな感じになっている…。


## 動作確認

### API

- postmanを使ってupdate, show共に動作を確認済み

### 画面側

- https://yeahcheese.localapp.jp/events から適当にイベントを選んで編集ボタンをクリック
（id=15のイベントであれば https://yeahcheese.localapp.jp/events/15/edit に遷移）
- どれかを空欄にするもしくは開始日＜終了日にするとバリデーションエラーが表示される
- エラーが出ないように値を入力し、「更新する」ボタンを押すと特に画面に変化はない
- イベント一覧に戻ると、該当イベントの内容が更新されている
（イベント一覧での表示順番は変化なし）