### PR TITLE
【写真閲覧画面】認証キー入力画面・該当イベントの写真閲覧画面を作成

### DIFF
--- a/yeahcheese/app/Http/Controllers/KeyinputController.php
+++ b/yeahcheese/app/Http/Controllers/KeyinputController.php
@@ -30,6 +30,12 @@ class KeyinputController extends Controller
         if (is_null($event)) {
             return redirect('/keyinput')->with('error', '認証キーが間違っています');
         }
+        elseif (date("Y-m-d") < $event->start_at) {
+            return redirect('/keyinput')->with('error', '公開期間前です');
+        }
+        elseif ($event->end_at < date("Y-m-d")) {
+            return redirect('/keyinput')->with('error', '公開期間が過ぎています');
+        }
         $photos = Photo::where('event_id', $event->id)->get();
         return view('events.show', ['event' => $event, 'photos' => $photos]);
     }

--- a/yeahcheese/app/Http/Controllers/KeyinputController.php
+++ b/yeahcheese/app/Http/Controllers/KeyinputController.php
@@ -36,7 +36,6 @@ class KeyinputController extends Controller
         elseif ($event->end_at < date("Y-m-d")) {
             return redirect('/keyinput')->with('error', '公開期間が過ぎています');
         }
-        $photos = Photo::where('event_id', $event->id)->get();
-        return view('events.show', ['event' => $event, 'photos' => $photos]);
+        return view('events.show', ['event' => $event]);
     }
 }

--- a/yeahcheese/app/Http/Controllers/KeyinputController.php
+++ b/yeahcheese/app/Http/Controllers/KeyinputController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Event;
+use App\Photo;
+use Illuminate\Http\Request;
+
+class KeyinputController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return view('keyinput');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $event = Event::where('authorization_key', $request->input('authorization_key'))->first();
+        if (is_null($event)) {
+            return redirect('/keyinput')->with('error', '認証キーが間違っています');
+        }
+        $photos = Photo::where('event_id', $event->id)->get();
+        return view('events.show', ['event' => $event, 'photos' => $photos]);
+    }
+}

--- a/yeahcheese/resources/views/events/show.blade.php
+++ b/yeahcheese/resources/views/events/show.blade.php
@@ -20,7 +20,7 @@
             </td>
         </tr>
     </table>
-    @foreach ($photos as $photo)
+    @foreach ($event->photos as $photo)
         <div style="margin: 10px;border: 1px solid;width:50%;">
             <img src="{{ \Storage::url($photo->path) }}" style="width:250px"><br>
             ID：{{ $photo->id }}<br>

--- a/yeahcheese/resources/views/events/show.blade.php
+++ b/yeahcheese/resources/views/events/show.blade.php
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset='utf-8'>
+        <title>even.show</title>
+        <style>body {padding: 80px;}</style>
+        @include('style-sheet')
+    </head>
+    <h1>写真一覧</h1>
+    <table class='table table-striped table-hover'>
+        <tr>
+            <th>イベント名</th><th>写真枚数</th>
+        </tr>
+        <tr>
+            <td>
+                {{ $event->name }}
+            </td>
+            <td>
+                {{ $event->photos()->count() }}
+            </td>
+        </tr>
+    </table>
+    @foreach ($photos as $photo)
+        <div style="margin: 10px;border: 1px solid;width:50%;">
+            <img src="{{ \Storage::url($photo->path) }}" style="width:250px"><br>
+            ID：{{ $photo->id }}<br>
+            Updated：{{ $photo->updated_at }}<br>
+        </div>
+    @endforeach
+</html>

--- a/yeahcheese/resources/views/events/show.blade.php
+++ b/yeahcheese/resources/views/events/show.blade.php
@@ -6,7 +6,7 @@
         <style>body {padding: 80px;}</style>
         @include('style-sheet')
     </head>
-    <h1>写真一覧</h1>
+    <h1>写真閲覧</h1>
     <table class='table table-striped table-hover'>
         <tr>
             <th>イベント名</th><th>写真枚数</th>

--- a/yeahcheese/resources/views/keyinput.blade.php
+++ b/yeahcheese/resources/views/keyinput.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset='utf-8'>
+        <title>keyinput</title>
+        <style>body {padding: 80px;}</style>
+    </head>
+    <h1>認証キー入力</h1>
+    @if (session('error'))
+        <p class="text-danger mt-3">
+            {{ session('error') }}
+        </p>
+    @endif
+    <form action="{{ route('keyinput.store') }}" method="POST">
+        {{ csrf_field() }}
+        <div>
+            <label>認証キー</label><br>
+            <input type="text" name="authorization_key" />
+        </div>
+        <div>
+            <input type="submit" value="送信（写真を見る）" />
+        </div>
+    </form>
+</html>

--- a/yeahcheese/routes/web.php
+++ b/yeahcheese/routes/web.php
@@ -20,6 +20,8 @@ Route::get('/', function () {
 Auth::routes();
 
 Route::get('/home', 'HomeController@index')->name('home');
+Route::get('/keyinput', 'KeyinputController@index')->name('keyinput');
+Route::post('/events/show', 'KeyinputController@store')->name('keyinput.store');
 
 Route::middleware('auth')->group(function () {
     Route::get('/events', 'EventController@index')->name('events.index');


### PR DESCRIPTION
close #37

## 要件

### 認証キー入力画面

- 正しい認証キーを入力するとイベントの写真閲覧画面に飛ぶ
- 正しくない場合はエラーメッセージを表示
- ログインは不要
- 公開期間外は見れない

### 写真閲覧画面

- 写真の一覧が見れる
＊研修Day4でもそうだったのだが、jpegしか表示できないっぽい。
（＊jpegだけでいいようです！）
![image](https://user-images.githubusercontent.com/54708270/83085069-ce65c900-a0c5-11ea-98ae-c05752f28096.png)



## 改修内容

- ルーティング、コントローラー、ビューをそれぞれのページ用に作成

## 動作確認

- 認証キー入力画面にアクセス https://yeahcheese.localapp.jp/keyinput
（今のところどこにもリンク貼ってないので直打ち）
- 存在しないキーを入力するとエラーメッセージが表示される
![image](https://user-images.githubusercontent.com/54708270/83011274-8eb2c900-a054-11ea-8464-01f45992ff88.png)

- 存在するが公開期間外のイベントのキーを入力するとエラーメッセージが表示される
- キーあり＆公開期間内のイベントのキーを入力すると写真閲覧画面に遷移
（URLは https://yeahcheese.localapp.jp/events/show ）
（キー入力せずにこのURLに直接アクセスしてもエラーになるのは仕様）
- 写真があれば、jpegは表示されているはず

<img width="1619" alt="スクリーンショット 2020-05-27 19 58 37" src="https://user-images.githubusercontent.com/54708270/83011216-7b9ff900-a054-11ea-8c8e-77c2a61e0381.png">

