### PR TITLE
【編集画面】写真をアップロードできるようにする

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -23,6 +23,7 @@ http {
     
     server {
         listen 80;
+        client_max_body_size 200m;
 
         set $need_redirect 1;
         if ($http_x_forwarded_proto = https) {
@@ -38,6 +39,7 @@ http {
         server_name  yeahcheese.localapp.jp;
         index index.php index.html;
         root /var/www/yeahcheese/public;
+        client_max_body_size 200m;
 
         ssl_certificate     /etc/ssl/server.crt;
         ssl_certificate_key /etc/ssl/server.key;

--- a/yeahcheese/app/Http/Controllers/Api/PhotoController.php
+++ b/yeahcheese/app/Http/Controllers/Api/PhotoController.php
@@ -30,7 +30,7 @@ class PhotoController extends Controller
     {
         
         $this->validate($request, [
-            'file' => 'required|image'
+            'file' => 'required|image|max:10240'
         ], [
             'file.required' => '画像が選択されていません',
             'file.image' => '画像ファイルではありません',

--- a/yeahcheese/app/Http/Controllers/Api/PhotoController.php
+++ b/yeahcheese/app/Http/Controllers/Api/PhotoController.php
@@ -41,7 +41,7 @@ class PhotoController extends Controller
             $photo->path = Storage::putFile('public', $request->file);  // 画像を保存
             $photo->event_id = $id;
             $photo->save();  // DBに追加
-            return ['success' => '登録しました!'];
+            return $photo;
         }
     }
 

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -74,6 +74,8 @@
                     })
                     .catch(err => {
                         this.messages = _.flatten(_.values(err.response.data.errors));
+                        this.messages.splice(0);
+                        this.messages.push('イベントが更新されました');
                     });
             },
             uploadPhoto() {
@@ -84,6 +86,8 @@
                     .then(response => {
                         this.photos.push(response.data);
                         this.$refs.imageFile.value = '';
+                        this.messages.splice(0);
+                        this.messages.push('アップロードが成功しました');
                     })
                     .catch(err => {
                         this.messages = _.flatten(_.values(err.response.data.errors));

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -60,7 +60,7 @@
             this.getPhotos();
         },
         methods: {
-            updateEvent() {    
+            updateEvent() {
                 axios
                     .put("/api/events/"+this.id, {
                         name: this.name,

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -14,7 +14,7 @@
                     <label>公開終了日</label><br>
                     <input type="date" name="end_at" v-model="end_at"/>
                 </div>
-                <p v-for="(message, index) in messages" :key="index">{{ message }}</p>
+                <p class="text-info" v-for="(message, index) in messages" :key="index">{{ message }}</p>
                 <div>
                     <button @click="updateEvent">更新する</button>
                 </div>

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -58,9 +58,9 @@
                         end_at: this.end_at
                     })
                     .then(response => {
-                        this.name = this.name;
-                        this.start_at = this.start_at;
-                        this.end_at = this.end_at;
+                        this.name = response.data.name;
+                        this.start_at = response.data.start_at;
+                        this.end_at = response.data.end_at;
                     })
                     .catch(err => {
                         this.message = err.response.data.errors;

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -14,7 +14,7 @@
                     <label>公開終了日</label><br>
                     <input type="date" name="end_at" v-model="end_at"/>
                 </div>
-                <p>{{ message }}</p>
+                <p v-for="(message, index) in messages" :key="index">{{ message }}</p>
                 <div>
                     <button @click="updateEvent">更新する</button>
                 </div>
@@ -40,7 +40,7 @@
                 name: '',
                 start_at: '',
                 end_at: '',
-                message: ''
+                messages: []
             };
         },
         mounted() {
@@ -63,7 +63,7 @@
                         this.end_at = response.data.end_at;
                     })
                     .catch(err => {
-                        this.message = err.response.data.errors;
+                        this.messages = _.flatten(_.values(err.response.data.errors));
                     });
             }
         }

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -18,6 +18,9 @@
                 <div>
                     <button @click="updateEvent">更新する</button>
                 </div>
+                <p><input ref="imageFile" type="file" accept="image/jpeg" required v-if="view" /></p>
+                <div>
+                    <button @click="uploadPhoto">アップロードする</button>
                 </div>
                 <li v-for="photo in photos" :key="photo.id">
                     <img style="max-width: 200px;" :src="'/storage/app/'+photo.path" />
@@ -72,6 +75,23 @@
                     .catch(err => {
                         this.messages = _.flatten(_.values(err.response.data.errors));
                     });
+            },
+            uploadPhoto() {
+                let params = new FormData();
+                params.append('file', this.$refs.imageFile.files[0]);
+                axios
+                    .post("/api/events/"+this.id+"/edit", params)
+                    .then(response => {
+                        this.photos.push(response.data);
+                        this.view = false;
+                        this.$nextTick(function() {
+                            this.view = true;
+                    });
+                    })
+                    .catch(err => {
+                        this.messages = _.flatten(_.values(err.response.data.errors));
+                    });
+            },
             getPhotos() {
                 axios
                     .get("/api/events/"+this.id+"/edit")

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -18,6 +18,10 @@
                 <div>
                     <button @click="updateEvent">更新する</button>
                 </div>
+                </div>
+                <li v-for="photo in photos" :key="photo.id">
+                    <img style="max-width: 200px;" :src="'/storage/app/'+photo.path" />
+                </li>
             </div>
         </div>
     </div>
@@ -40,7 +44,9 @@
                 name: '',
                 start_at: '',
                 end_at: '',
-                messages: []
+                messages: [],
+                photos: [],
+                view: true,
             };
         },
         mounted() {
@@ -48,6 +54,7 @@
             this.name = this.event.name;
             this.start_at = this.event.start_at;
             this.end_at = this.event.end_at
+            this.getPhotos();
         },
         methods: {
             updateEvent() {    
@@ -65,6 +72,12 @@
                     .catch(err => {
                         this.messages = _.flatten(_.values(err.response.data.errors));
                     });
+            getPhotos() {
+                axios
+                    .get("/api/events/"+this.id+"/edit")
+                    .then(response => {
+                        this.photos = response.data;
+                    })
             }
         }
     }

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -18,7 +18,7 @@
                 <div>
                     <button @click="updateEvent">更新する</button>
                 </div>
-                <p><input ref="imageFile" type="file" accept="image/jpeg" required v-if="view" /></p>
+                <p><input ref="imageFile" type="file" accept="image/jpeg" required /></p>
                 <div>
                     <button @click="uploadPhoto">アップロードする</button>
                 </div>
@@ -83,10 +83,7 @@
                     .post("/api/events/"+this.id+"/edit", params)
                     .then(response => {
                         this.photos.push(response.data);
-                        this.view = false;
-                        this.$nextTick(function() {
-                            this.view = true;
-                    });
+                        this.$refs.imageFile.value = '';
                     })
                     .catch(err => {
                         this.messages = _.flatten(_.values(err.response.data.errors));

--- a/yeahcheese/resources/js/components/EventEditComponent.vue
+++ b/yeahcheese/resources/js/components/EventEditComponent.vue
@@ -71,11 +71,11 @@
                         this.name = response.data.name;
                         this.start_at = response.data.start_at;
                         this.end_at = response.data.end_at;
+                        this.messages.splice(0);
+                        this.messages.push('イベントが更新されました');
                     })
                     .catch(err => {
                         this.messages = _.flatten(_.values(err.response.data.errors));
-                        this.messages.splice(0);
-                        this.messages.push('イベントが更新されました');
                     });
             },
             uploadPhoto() {


### PR DESCRIPTION
close #36 

 上記イシューの要件を満たすように改修。


## 未対応になってること

- 画像を選択せずにアップロードボタンを押した際のエラーはPhotoControllerのバリデーションに書いた「画像が選択されていません」にしたいが、「画像ファイルではありません」になってしまう。


- ~画像の容量のバリデーションはうまくいってなくて、10M以下でも下記エラーメッセージが表示される~
（追記）↑こちらは対応しました。
docker内のphp.iniファイルを書き換えられていませんでした。（アップロードできるファイル（upload_max_filesize）・POSTできるファイルサイズ（post_max_size）の最大値の変更。）

![image](https://user-images.githubusercontent.com/54708270/83121999-fe38bf00-a10d-11ea-8aed-f71bf13aaaf4.png)