### PR TITLE
【写真閲覧】updated_atの非表示・キー入力画面にBootstrap導入

### DIFF
--- a/yeahcheese/resources/views/events/show.blade.php
+++ b/yeahcheese/resources/views/events/show.blade.php
@@ -24,7 +24,6 @@
         <div style="margin: 10px;border: 1px solid;width:50%;">
             <img src="{{ \Storage::url($photo->path) }}" style="width:250px"><br>
             ID：{{ $photo->id }}<br>
-            Updated：{{ $photo->updated_at }}<br>
         </div>
     @endforeach
 </html>

--- a/yeahcheese/resources/views/keyinput.blade.php
+++ b/yeahcheese/resources/views/keyinput.blade.php
@@ -4,6 +4,7 @@
         <meta charset='utf-8'>
         <title>keyinput</title>
         <style>body {padding: 80px;}</style>
+        @include('style-sheet')
     </head>
     <h1>認証キー入力</h1>
     @if (session('error'))


### PR DESCRIPTION
ちょい改修で、issueないです！

## 改修内容

1. 写真閲覧画面でupdated_atの表示を止める

理由は、日本時間じゃなくて紛らわしいのと、そもそも閲覧者に伝える必要もないので、時刻表示を変えるのではなく非表示で対応。

2. 認証キー入力画面でBootstrapを使えるようにして見た目を整える

理由は、流石に入力エリアやボタンが小さすぎて使い勝手が悪かったからと、Bootstrapを使えるようにする部分だけの共通テンプレートがあったのでそれを追加するだけだったから。


## 動作確認

- [認証キー入力画面](https://yeahcheese.localapp.jp/keyinput)の見た目がマシになっているのを確認

<img width="881" alt="スクリーンショット 2020-05-29 1 04 47" src="https://user-images.githubusercontent.com/54708270/83165570-ad928780-a148-11ea-9d04-df3332520d1a.png">


- 画像が閲覧可能なイベントの認証キーを入力して写真閲覧画面に行き、各画像の下にIDが表示され、Updateは表示されていないことを確認


