### PR TITLE
【テスト】API用のEventControllerのテストを作る

### DIFF
--- a/yeahcheese/database/factories/EventFactory.php
+++ b/yeahcheese/database/factories/EventFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Event;
+use App\User;
+
+$factory->define(Event::class, function () {
+    return [
+        'name' => 'party',
+        'start_at' => '2019-10-10',
+        'end_at' => '2020-04-01',
+        'authorization_key' => '11111111',
+        'user_id' => factory(User::class)->create()->id,
+    ];
+});

--- a/yeahcheese/database/factories/UserFactory.php
+++ b/yeahcheese/database/factories/UserFactory.php
@@ -19,7 +19,6 @@ use Illuminate\Support\Str;
 
 $factory->define(User::class, function (Faker $faker) {
     return [
-        'name' => $faker->name,
         'email' => $faker->unique()->safeEmail,
         'email_verified_at' => now(),
         'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password

--- a/yeahcheese/tests/Feature/Api/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/Api/EventControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class EventControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testExample()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/yeahcheese/tests/Feature/Api/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/Api/EventControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api;
 
+use App\Event;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
@@ -11,14 +12,24 @@ class EventControllerTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * A basic feature test example.
-     *
-     * @return void
+     * show
      */
-    public function testExample()
-    {
-        $response = $this->get('/');
 
-        $response->assertStatus(200);
+    /**
+     * @testdox 指定したidのイベントのデータが取得出来る。
+     */
+    public function testSuccessShow()
+    {
+        $event = factory(Event::class)->create();
+
+        $ret = $this->get('/api/events/' . $event->id);
+        $ret->assertSuccessful();
+        $ret->assertJson([
+            'name' => 'party',
+            'start_at' => '2019-10-10',
+            'end_at' => '2020-04-01',
+            'authorization_key' => '11111111',
+            'user_id' => 1
+        ]);
     }
 }

--- a/yeahcheese/tests/Feature/Api/EventControllerTest.php
+++ b/yeahcheese/tests/Feature/Api/EventControllerTest.php
@@ -32,4 +32,38 @@ class EventControllerTest extends TestCase
             'user_id' => 1
         ]);
     }
+
+    /**
+     * update
+     */
+
+    /**
+     * @testdox イベントのデータが更新出来る。
+     */
+    public function testSuccessUpdate()
+    {
+        $event = factory(Event::class)->create();
+
+        $response = $this->putJson('/api/events/' . $event->id, [
+            'name' => 'ceremony',
+            'start_at' => '2019-05-05',
+            'end_at' => '2020-05-05',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('events', [
+            'name' => 'ceremony',
+            'start_at' => '2019-05-05',
+            'end_at' => '2020-05-05',
+            'authorization_key' => '11111111',
+            'user_id' => 1
+        ]);
+        $response->assertJson([
+            'name' => 'ceremony',
+            'start_at' => '2019-05-05',
+            'end_at' => '2020-05-05',
+            'authorization_key' => '11111111',
+            'user_id' => 1
+        ]);
+    }
 }


### PR DESCRIPTION
close #51 

## 改修内容

- app/Http/Controllers/Api/EventController.php のテストを作成。

- show, updateメソッドのみなので、テストもその2つ。

- updateのテストでは、更新できるカラムは name, start_at, end_at だけなので、それらを上書きし、他の authorization_key, user_id は値が変わっていないことを確認している。


 ## 動作確認

vendor/bin/phpunit で確認済み
